### PR TITLE
better casing for `NO_PRECOMPILED_HEADERS` warning

### DIFF
--- a/llua/Lua.hx
+++ b/llua/Lua.hx
@@ -11,7 +11,7 @@ import llua.Convert;
 @:build(linc.Linc.touch())
 @:build(linc.Linc.xml('lua'))
 #end
-#if (lime && flixel && (!NO_PRECOMPILED_HEADERS || SHUT_UP_LINC_LUAJIT))
+#if ((android || linux) && (!NO_PRECOMPILED_HEADERS || SHUT_UP_LINC_LUAJIT))
 #error "\nlinc_luajit might require `NO_PRECOMPILED_HEADERS` to be set in your project.xml\nThis error is to help anyone compiling certain FNF engines that don't have this set already\nONLY IF YOU KNOW WHAT YOU'RE DOING, add '<haxedef name=\"SHUT_UP_LINC_LUAJIT\"/>' to your project.xml\n\nTO FIX: Add '<haxedef name=\"NO_PRECOMPILED_HEADERS\"/>' to your project.xml right before '</project>'." 
 #end
 extern class Lua {


### PR DESCRIPTION
this only happens in GNU compilers (included android cuz r19 and down uses GCC.) Clang is fine with it and `lime && flixel` case is useless cuz it's hxcpp related.